### PR TITLE
[기능 추가] GetterSetter, JsLinker and Optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Minecraft Bukkit Scripting with JS by Netherald
 </div>
 
 ## How to apply?
-Download Paper or Bungee Version. and put it to plugins folder.\
+Download Paper or Bungee Version. and put it to the plugins folder.\
 Script folder is `plugins/js`!
 ## How to build?
 Run build task of Bukkit or Bungee module!

--- a/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/MineJsBukkit.kt
+++ b/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/MineJsBukkit.kt
@@ -29,23 +29,27 @@ class MineJsBukkit : JavaPlugin() {
     override fun onEnable() {
         instance = this
         saveDefaultConfig()
-        Bukkit.getPluginManager().registerEvents(PlayerListener(this), this)
+        Bukkit.getPluginManager().registerEvents(PlayerListener(), this)
         Bukkit.getPluginManager().registerEvents(EntityListener(), this)
         Bukkit.getPluginManager().registerEvents(BlockListener(), this)
-        Bukkit.getPluginManager().registerEvents(MiscListener(this), this)
+        Bukkit.getPluginManager().registerEvents(MiscListener(), this)
 
         getCommand("minejs")!!.setExecutor(MineJSCommand(this))
         getCommand("minejs")!!.tabCompleter = MineJSTabCompleter()
 
         protocolEnabled = Bukkit.getPluginManager().isPluginEnabled("ProtocolLib")
-        if(protocolEnabled)
+        if(protocolEnabled) {
             ProtocolUtil.init()
-        else
-            logger.warning("You may not use packet feature. Install ProtocolLib to use packet feature!")
+        } else {
+            logger.warning("ProtocolLib is required to use the packet feature. Please install ProtocolLib.")
+        }
 
         logger.info("Loading scripts...")
-        if(!scriptsDir.exists())
+
+        if(!scriptsDir.exists()) {
             scriptsDir.mkdir()
+        }
+
         load()
     }
 

--- a/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/event/BlockListener.kt
+++ b/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/event/BlockListener.kt
@@ -1,52 +1,24 @@
 package org.netherald.minejs.bukkit.event
 
-import com.eclipsesource.v8.V8Object
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.block.BlockBreakEvent
 import org.bukkit.event.block.BlockPlaceEvent
-import org.bukkit.event.entity.EntityDamageEvent
-import org.netherald.minejs.bukkit.utils.ObjectUtils
 import org.netherald.minejs.common.ScriptLoader
 
 class BlockListener : Listener {
     @EventHandler
     fun onBlockBreak(event: BlockBreakEvent) {
         ScriptLoader.invokeEvent("onBreakBlock") {
-            add("block", V8Object(runtime).apply(ObjectUtils.createBlockObject(event.block, runtime)))
-            add("player", V8Object(runtime).apply(ObjectUtils.createPlayerObject(event.player, runtime)))
-            registerJavaMethod({ receiver, arguments ->
-                if (arguments.length() > 0) {
-                    if (arguments[0] == true) {
-                        event.isCancelled = true;
-                    } else if (arguments[0] == false) {
-                        event.isCancelled = false;
-                    }
-                }
-            }, "setCancelled")
-            registerJavaMethod({ receiver, arguments ->
-                event.isCancelled = true
-            }, "cancel")
+            registerBlockEvent(event, event.player)
         }
     }
 
     @EventHandler
     fun onBlockPlace(event: BlockPlaceEvent) {
         ScriptLoader.invokeEvent("onPlaceBlock") {
-            add("block", V8Object(runtime).apply(ObjectUtils.createBlockObject(event.block, runtime)))
-            add("player", V8Object(runtime).apply(ObjectUtils.createPlayerObject(event.player, runtime)))
-            registerJavaMethod({ receiver, arguments ->
-                if (arguments.length() > 0) {
-                    if (arguments[0] == true) {
-                        event.isCancelled = true;
-                    } else if (arguments[0] == false) {
-                        event.isCancelled = false;
-                    }
-                }
-            }, "setCancelled")
-            registerJavaMethod({ receiver, arguments ->
-                event.isCancelled = true
-            }, "cancel")
+            registerBlockEvent(event, event.player)
+            event.blockPlaced
         }
     }
 }

--- a/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/event/EntityListener.kt
+++ b/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/event/EntityListener.kt
@@ -1,7 +1,6 @@
 package org.netherald.minejs.bukkit.event
 
 import com.eclipsesource.v8.V8Object
-import org.bukkit.entity.FallingBlock
 import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
@@ -15,44 +14,18 @@ class EntityListener : Listener {
     @EventHandler
     fun onDamageByEntity(event: EntityDamageByEntityEvent) {
         ScriptLoader.invokeEvent("onEntityDamage") {
-            add("reason", event.cause.toString().lowercase())
             if(event.damager is Player)
                 add("used", V8Object(runtime).apply(ObjectUtils.createItemStackObject((event.damager as Player).inventory.itemInMainHand, runtime)))
-            add("victim", V8Object(runtime).apply(ObjectUtils.createEntityObject(event.entity, runtime)))
             add("attacker", V8Object(runtime).apply(ObjectUtils.createEntityObject(event.damager, runtime)))
 
-            registerJavaMethod({ receiver, arguments ->
-                if (arguments.length() > 0) {
-                    if (arguments[0] == true) {
-                        event.isCancelled = true;
-                    } else if (arguments[0] == false) {
-                        event.isCancelled = false;
-                    }
-                }
-            }, "setCancelled")
-            registerJavaMethod({ receiver, arguments ->
-                event.isCancelled = true
-            }, "cancel")
+            registerEntityDamageEvent(event)
         }
     }
 
     @EventHandler
     fun onDamage(event: EntityDamageEvent) {
         ScriptLoader.invokeEvent("onEntityDamage") {
-            add("reason", event.cause.toString().lowercase())
-            add("victim", V8Object(runtime).apply(ObjectUtils.createEntityObject(event.entity, runtime)))
-            registerJavaMethod({ receiver, arguments ->
-                if (arguments.length() > 0) {
-                    if (arguments[0] == true) {
-                        event.isCancelled = true;
-                    } else if (arguments[0] == false) {
-                        event.isCancelled = false;
-                    }
-                }
-            }, "setCancelled")
-            registerJavaMethod({ receiver, arguments ->
-                event.isCancelled = true
-            }, "cancel")
+            registerEntityDamageEvent(event)
         }
     }
 

--- a/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/event/EventUtil.kt
+++ b/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/event/EventUtil.kt
@@ -1,0 +1,41 @@
+package org.netherald.minejs.bukkit.event
+
+import com.eclipsesource.v8.JavaCallback
+import com.eclipsesource.v8.V8Object
+import org.bukkit.entity.Player
+import org.bukkit.event.Cancellable
+import org.bukkit.event.block.BlockEvent
+import org.bukkit.event.entity.EntityDamageEvent
+import org.netherald.minejs.bukkit.utils.ObjectUtils
+import org.netherald.minejs.bukkit.utils.getOrNull
+
+fun V8Object.registerCancellable(event: Cancellable) {
+    registerJavaMethod({ _, arguments ->
+        event.isCancelled = arguments.getOrNull(0) == true
+    }, "setCancelled")
+
+    registerJavaMethod(JavaCallback { _, _ ->
+        return@JavaCallback event.isCancelled
+    }, "isCancelled")
+
+    registerJavaMethod({ _, _ ->
+        event.isCancelled = true
+    }, "cancel")
+}
+
+fun V8Object.registerBlockEvent(event: BlockEvent, player: Player) {
+    add("block", V8Object(runtime).apply(ObjectUtils.createBlockObject(event.block, runtime)))
+    add("player", V8Object(runtime).apply(ObjectUtils.createPlayerObject(player, runtime)))
+    if (event is Cancellable) {
+        registerCancellable(event)
+    }
+}
+
+fun V8Object.registerEntityDamageEvent(event: EntityDamageEvent) {
+    add("reason", event.cause.toString().lowercase())
+    add("victim", V8Object(runtime).apply(ObjectUtils.createEntityObject(event.entity, runtime)))
+}
+
+fun V8Object.registerPlayer(player: Player) {
+    add("player", V8Object(runtime).apply(ObjectUtils.createPlayerObject(player, runtime)))
+}

--- a/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/event/MiscListener.kt
+++ b/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/event/MiscListener.kt
@@ -6,44 +6,43 @@ import org.bukkit.Bukkit
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.plugin.java.JavaPlugin
+import org.netherald.minejs.bukkit.MineJsBukkit
+import org.netherald.minejs.bukkit.utils.GetterSetter
 import org.netherald.minejs.bukkit.utils.ObjectUtils
+import org.netherald.minejs.bukkit.utils.getOrNull
 import org.netherald.minejs.common.ScriptLoader
 
-class MiscListener(val plugin: JavaPlugin) : Listener {
-
+class MiscListener : Listener {
     @EventHandler
     fun ping(event: PaperServerListPingEvent) {
-        Bukkit.getScheduler().runTask(plugin, Runnable {
+        Bukkit.getScheduler().runTask(MineJsBukkit.instance, Runnable {
             ScriptLoader.invokeEvent("onServerListPing") {
-                registerJavaMethod({ receiver, arguments ->
-                    if (arguments.length() > 0) {
-                        if (arguments[0] == true) {
-                            event.isCancelled = true;
-                        } else if (arguments[0] == false) {
-                            event.isCancelled = false;
-                        }
+                GetterSetter<Int>("numPlayers") {
+                    getter {
+                        event.numPlayers
                     }
-                }, "setCancelled")
-                registerJavaMethod({ receiver, arguments ->
-                    if (arguments.length() > 0)
-                        event.numPlayers = arguments[0] as Int
-                }, "setPlayers")
-                registerJavaMethod(JavaCallback { receiver, arguments ->
-                    return@JavaCallback event.numPlayers
-                }, "players")
-                registerJavaMethod({ receiver, arguments ->
-                    if (arguments.length() > 0)
-                        event.maxPlayers = arguments[0] as Int
-                }, "setMaxPlayers")
-                registerJavaMethod(JavaCallback { receiver, arguments ->
-                    return@JavaCallback event.maxPlayers
-                }, "maxPlayers")
-                registerJavaMethod(JavaCallback { receiver, arguments ->
-                    if(event.shouldHidePlayers())
-                        event.setHidePlayers(false)
-                    else
-                        event.setHidePlayers(true)
+
+                    setter {
+                        event.numPlayers = it
+                    }
+                }
+
+                GetterSetter<Int>("maxPlayers") {
+                    getter {
+                        event.maxPlayers
+                    }
+
+                    setter {
+                        event.maxPlayers = it
+                    }
+                }
+
+                registerJavaMethod(JavaCallback { _, _ ->
+                    event.setHidePlayers(!event.shouldHidePlayers())
                 }, "hidePlayer")
+
+                registerCancellable(event)
+
             }
         })
     }

--- a/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/event/PlayerListener.kt
+++ b/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/event/PlayerListener.kt
@@ -2,20 +2,16 @@ package org.netherald.minejs.bukkit.event
 
 import com.eclipsesource.v8.V8Object
 import io.papermc.paper.event.player.AsyncChatEvent
-import net.kyori.adventure.text.Component
-import net.kyori.adventure.text.TextComponent
-import net.kyori.adventure.text.TranslatableComponent
 import org.bukkit.Bukkit
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.entity.FoodLevelChangeEvent
 import org.bukkit.event.player.*
-import org.bukkit.plugin.Plugin
-import org.netherald.minejs.bukkit.utils.MessageUtils
-import org.netherald.minejs.bukkit.utils.ObjectUtils
+import org.netherald.minejs.bukkit.MineJsBukkit
+import org.netherald.minejs.bukkit.utils.*
 import org.netherald.minejs.common.ScriptLoader
 
-class PlayerListener(val plugin: Plugin) : Listener {
+class PlayerListener : Listener {
     /*
     @EventHandler
     fun playerMove(event: PlayerMoveEvent) {
@@ -42,85 +38,76 @@ class PlayerListener(val plugin: Plugin) : Listener {
     @EventHandler
     fun playerJoin(event: PlayerJoinEvent) {
         ScriptLoader.invokeEvent("onPlayerJoin") {
-            add("player", V8Object(runtime).apply(ObjectUtils.createPlayerObject(event.player, runtime)))
-            add("joinMessage", MessageUtils.toMiniMessage(event.joinMessage()!!))
-            registerJavaMethod({ receiver, arguments ->
-                if (arguments.length() > 0) {
-                    event.joinMessage(MessageUtils.build(arguments[0].toString()))
+            GetterSetter<String>("joinMessage") {
+                getter {
+                    MessageUtils.toMiniMessage(event.joinMessage()!!)
                 }
-                if (arguments.length() == 0) {
-                    event.joinMessage(null)
+
+                setter {
+                    event.joinMessage(MessageUtils.build(it))
                 }
-            }, "setJoinMessage")
+            }
+            registerPlayer(event.player)
         }
     }
 
     @EventHandler
     fun worldChange(event: PlayerChangedWorldEvent) {
         ScriptLoader.invokeEvent("onPlayerWorldChange") {
-            add("player", V8Object(runtime).apply(ObjectUtils.createPlayerObject(event.player, runtime)))
             add("from", V8Object(runtime).apply(ObjectUtils.createWorldObject(event.from, runtime)))
+            registerPlayer(event.player)
         }
     }
 
     @EventHandler
     fun onPlayerFoodLevelChange(event: FoodLevelChangeEvent) {
         ScriptLoader.invokeEvent("onFoodLevelChange") {
-            add("player", V8Object(runtime).apply(ObjectUtils.createPlayerObject(Bukkit.getPlayer(event.entity.name)!!, runtime)))
-            add("foodLevel", event.foodLevel)
-
-            registerJavaMethod({ receiver, arguments ->
-                if (arguments.length() > 0) {
-                    event.foodLevel = arguments[0] as Int
-                    add("foodLevel", event.foodLevel)
+            GetterSetter<Int>("foodLevel") {
+                getter {
+                    event.foodLevel
                 }
-            }, "setFoodLevel")
 
-            registerJavaMethod({ receiver, arguments ->
-                if (arguments.length() > 0) {
-                    if (arguments[0] == true) {
-                        event.isCancelled = true;
-                    } else if (arguments[0] == false) {
-                        event.isCancelled = false;
-                    }
+                setter {
+                    event.foodLevel = it
                 }
-            }, "setCancelled")
-            registerJavaMethod({ receiver, arguments ->
-                event.isCancelled = true
-            }, "cancel")
+            }
+            registerPlayer(Bukkit.getPlayer(event.entity.name)!!)
+            registerCancellable(event)
         }
     }
 
     @EventHandler
     fun playerQuit(event: PlayerQuitEvent) {
         ScriptLoader.invokeEvent("onPlayerQuit") {
-            add("player", V8Object(runtime).apply(ObjectUtils.createPlayerObject(event.player, runtime)))
-            add("quitMessage", MessageUtils.toMiniMessage(event.quitMessage()!!))
-            registerJavaMethod({ receiver, arguments ->
-                if (arguments.length() > 0) {
-                    event.quitMessage(MessageUtils.build(arguments[0].toString()))
+            GetterSetter<String>("quitMessage") {
+                getter {
+                    MessageUtils.toMiniMessage(event.quitMessage()!!)
                 }
-                if (arguments.length() == 0) {
-                    event.quitMessage(null)
+
+                setter {
+                    event.quitMessage(MessageUtils.build(it))
                 }
-            }, "setQuitMessage")
+            }
+            registerPlayer(event.player)
         }
     }
 
     @EventHandler
     fun asyncChat(event: AsyncChatEvent) {
-        Bukkit.getScheduler().runTask(plugin, Runnable {
+        Bukkit.getScheduler().runTask(MineJsBukkit.instance, Runnable {
             ScriptLoader.invokeEvent("onPlayerChat") {
-                add("player", V8Object(runtime).apply(ObjectUtils.createPlayerObject(event.player, runtime)))
-                add("message", MessageUtils.toMiniMessage(event.message()))
-                registerJavaMethod({ receiver, arguments ->
-                    if (arguments.length() > 0) {
-                        event.message(MessageUtils.build(arguments[0] as String))
+                GetterSetter<String>("message") {
+                    getter {
+                        MessageUtils.toMiniMessage(event.message())
                     }
-                }, "setMessage")
-                registerJavaMethod({ receiver, arguments ->
-                    event.isCancelled = true
-                }, "cancel")
+
+                    setter {
+                        event.message(MessageUtils.build(it))
+                    }
+                }
+
+                registerPlayer(event.player)
+                registerCancellable(event)
             }
         })
     }
@@ -128,32 +115,18 @@ class PlayerListener(val plugin: Plugin) : Listener {
     @EventHandler
     fun playerInteract(event: PlayerInteractEvent) {
         ScriptLoader.invokeEvent("onPlayerInteract") {
-            add("player", V8Object(runtime).apply(ObjectUtils.createPlayerObject(event.player, runtime)))
             add("action", event.action.name)
-            if (event.clickedBlock != null) add("clickedBlock", V8Object(runtime).apply(ObjectUtils.createBlockObject(event.clickedBlock!!, runtime)))
-            else addUndefined("clickedBlock")
-            registerJavaMethod({ receiver, arguments ->
-                if (arguments.length() > 0) {
-                    if (arguments[0] == true) {
-                        event.isCancelled = true;
-                    } else if (arguments[0] == false) {
-                        event.isCancelled = false;
-                    }
-                }
-            }, "setCancelled")
-            registerJavaMethod({ receiver, arguments ->
-                event.isCancelled = true
-            }, "cancel")
+            addNullable("clickedBlock", event.clickedBlock?.let { V8Object(runtime).apply(ObjectUtils.createBlockObject(it, runtime)) })
+            registerPlayer(event.player)
+            registerCancellable(event)
         }
+
         ScriptLoader.invokeEvent("onClick") {
-            add("player", V8Object(runtime).apply(ObjectUtils.createPlayerObject(event.player, runtime)))
             add("clickSide", if(event.action.toString().contains("RIGHT")) "right" else "left")
             add("isAir", event.action.toString().contains("AIR"))
-            if (event.clickedBlock != null) add("clicked", V8Object(runtime).apply(ObjectUtils.createBlockObject(event.clickedBlock!!, runtime)))
-            else addUndefined("clicked")
-            registerJavaMethod({ receiver, arguments ->
-                event.isCancelled = true
-            }, "cancel")
+            addNullable("clickedBlock", event.clickedBlock?.let { V8Object(runtime).apply(ObjectUtils.createBlockObject(it, runtime)) })
+            registerPlayer(event.player)
+            registerCancellable(event)
         }
     }
 }

--- a/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/impl/ItemManagerImpl.kt
+++ b/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/impl/ItemManagerImpl.kt
@@ -8,9 +8,8 @@ import org.netherald.minejs.common.interfaces.ItemManager
 import org.netherald.minejs.bukkit.utils.ObjectUtils.createItemStackObject
 
 class ItemManagerImpl : ItemManager {
-
-    override fun itemOf(runtime: V8, name: String): V8Object {
-        val material = Material.getMaterial(name.uppercase()) ?: return V8Object(runtime)
-        return V8Object(runtime).apply(createItemStackObject(ItemStack(material),runtime))
+    override fun itemOf(runtime: V8, material: String): V8Object {
+        val bukkitMaterial = Material.getMaterial(material.uppercase()) ?: return V8Object(runtime)
+        return V8Object(runtime).apply(createItemStackObject(ItemStack(bukkitMaterial),runtime))
     }
 }

--- a/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/impl/JavaManagerImpl.kt
+++ b/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/impl/JavaManagerImpl.kt
@@ -7,7 +7,7 @@ import java.net.URLClassLoader
 
 class JavaManagerImpl : JavaManager {
 
-    val externalLoaders = ArrayList<URLClassLoader>()
+    private val externalLoaders = ArrayList<URLClassLoader>()
 
     init {
         val libraries = File(MineJsBukkit.instance.dataFolder, "libraries")
@@ -41,15 +41,11 @@ class JavaManagerImpl : JavaManager {
         val imports = section.getStringList(filename)
         val result = ArrayList<Class<*>>()
         for (import in imports) {
-            lateinit var clazz: Class<*>
-
-            try {
-                clazz = Class.forName(import)
+            result.add(try {
+                Class.forName(import)
             } catch (ex: ClassNotFoundException) {
-                clazz = getClass(import)
-            }
-
-            result.add(clazz)
+                getClass(import)
+            })
         }
 
         return result

--- a/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/impl/PlayerManagerImpl.kt
+++ b/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/impl/PlayerManagerImpl.kt
@@ -26,8 +26,7 @@ class PlayerManagerImpl : PlayerManager {
     }
 
     override fun playerOf(runtime: V8, name: String): V8Object {
-        val player = Bukkit.getPlayer(name)
-        return if (player != null) V8Object(runtime).apply(createPlayerObject(player, runtime))
-            else V8Object(runtime)
+        val player = Bukkit.getPlayer(name) ?: return V8Object(runtime)
+        return V8Object(runtime).apply(createPlayerObject(player, runtime))
     }
 }

--- a/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/impl/command/CustomCommand.kt
+++ b/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/impl/command/CustomCommand.kt
@@ -19,7 +19,10 @@ class CustomCommand(val command: Command) : BukkitCommand(command.name) {
         for(arg in args) {
             argsV8.push(arg)
         }
-        command.callback.call(command.runtime, V8Array(command.runtime).push(argsV8).push(V8Object(command.runtime).apply(ObjectUtils.createCommandSenderObject(sender, command.runtime))))
+        command.callback.call(command.runtime, V8Array(command.runtime)
+                .push(argsV8)
+                .push(V8Object(command.runtime).apply(ObjectUtils.createCommandSenderObject(sender, command.runtime))))
+
         return true
     }
 }

--- a/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/linker/JsLinkable.kt
+++ b/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/linker/JsLinkable.kt
@@ -1,0 +1,4 @@
+package org.netherald.minejs.bukkit.linker
+
+interface JsLinkable {
+}

--- a/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/linker/LinkableWrapper.kt
+++ b/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/linker/LinkableWrapper.kt
@@ -1,0 +1,5 @@
+package org.netherald.minejs.bukkit.linker
+
+interface LinkableWrapper<T> {
+    fun unwrap(): T
+}

--- a/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/linker/V8Converter.kt
+++ b/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/linker/V8Converter.kt
@@ -1,0 +1,51 @@
+package org.netherald.minejs.bukkit.linker
+
+import com.eclipsesource.v8.V8
+import com.eclipsesource.v8.V8Array
+import com.eclipsesource.v8.V8Object
+import org.netherald.minejs.bukkit.linker.annotation.JsLinkMethod
+import org.netherald.minejs.bukkit.linker.annotation.JsLinkValue
+
+object V8Converter {
+    fun fromV8(js: V8Object): JsLinkable {
+        val clazz = Class.forName(js.getString("link_class"))
+        val values = clazz.declaredFields.map { js.get(it.name) }.toTypedArray()
+        return clazz.getDeclaredConstructor(*values.map { it::class.java }.toTypedArray()).newInstance(*values) as JsLinkable
+    }
+
+    fun toV8(jvm: JsLinkable, runtime: V8): V8Object {
+        val obj = V8Object(runtime)
+        obj.add("link_class", jvm::class.java.name)
+        for (field in jvm::class.java.declaredFields) {
+            field.isAccessible = true
+            if (field.isAnnotationPresent(JsLinkValue::class.java)) {
+                safeAdd(obj, field.name, field.get(jvm), runtime)
+            }
+        }
+        for (method in jvm::class.java.declaredMethods) {
+            obj.registerJavaMethod({ _, parameters ->
+                method.isAccessible = true
+                if (method.isAnnotationPresent(JsLinkMethod::class.java)) {
+                    method.invoke(jvm, *retrieveArray(parameters));
+                }
+            }, method.name)
+        }
+        return obj
+    }
+
+    fun safeAdd(obj: V8Object, key: String, value: Any, runtime: V8) {
+        when (value) {
+            is String -> obj.add(key, value)
+            is Boolean -> obj.add(key, value)
+            is Double -> obj.add(key, value)
+            is Int -> obj.add(key, value)
+            is JsLinkable -> obj.add(key, toV8(value, runtime))
+        }
+    }
+
+    fun retrieveArray(array: V8Array): Array<Any> {
+        return Array(array.length()) {
+            array.get(it)
+        }
+    }
+}

--- a/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/linker/annotation/JsLinkMethod.kt
+++ b/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/linker/annotation/JsLinkMethod.kt
@@ -1,0 +1,3 @@
+package org.netherald.minejs.bukkit.linker.annotation
+
+annotation class JsLinkMethod()

--- a/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/linker/annotation/JsLinkValue.kt
+++ b/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/linker/annotation/JsLinkValue.kt
@@ -1,0 +1,3 @@
+package org.netherald.minejs.bukkit.linker.annotation
+
+annotation class JsLinkValue()

--- a/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/utils/GetterSetter.kt
+++ b/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/utils/GetterSetter.kt
@@ -1,0 +1,43 @@
+package org.netherald.minejs.bukkit.utils
+
+import com.eclipsesource.v8.JavaCallback
+import com.eclipsesource.v8.V8Object
+
+class GetterSetter<T>(init: GetterSetter<T>.() -> Unit) {
+    private lateinit var getterValue: () -> T
+    private lateinit var setterValue: (T) -> Unit
+
+    init {
+        init(this)
+    }
+
+    fun getter(getter: () -> T) {
+        this.getterValue = getter
+    }
+
+    fun setter(setter: (T) -> Unit) {
+        this.setterValue = setter
+    }
+
+    fun register(name: String, obj: V8Object) {
+        if(this::getterValue.isInitialized) {
+            obj.registerJavaMethod(JavaCallback { _, _ ->
+                this.getterValue()
+            }, "get${name.replaceFirstChar { it.uppercaseChar() }}")
+        }
+
+        if(this::setterValue.isInitialized) {
+            obj.registerJavaMethod(JavaCallback { _, parameters ->
+                @Suppress("unchecked_cast")
+                this.setterValue(parameters.getOrNull(0) as T)
+            }, "set${name.replaceFirstChar { it.uppercaseChar() }}")
+        }
+    }
+}
+
+@Suppress("FunctionName")
+fun <T> V8Object.GetterSetter(name: String, init: GetterSetter<T>.() -> Unit): GetterSetter<T> {
+    return GetterSetter(init).also {
+        it.register(name, this)
+    }
+}

--- a/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/utils/ProtocolUtil.kt
+++ b/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/utils/ProtocolUtil.kt
@@ -16,23 +16,21 @@ object ProtocolUtil {
     }
 
     fun createPacketContainer(isClient: Boolean, packetId: String, senderRaw: String): PacketContainer {
-        lateinit var type: Class<out PacketTypeEnum>
-
-        if(isClient) {
+        val type: Class<out PacketTypeEnum> = if(isClient) {
             when(senderRaw.lowercase()) {
-                "play" -> type = PacketType.Play.Client::class.java
-                "handshake" -> type = PacketType.Handshake.Client::class.java
-                "login" -> type = PacketType.Login.Client::class.java
-                "status" -> type = PacketType.Status.Client::class.java
-                else -> type = PacketType.Play.Client::class.java
+                "play" -> PacketType.Play.Client::class.java
+                "handshake" -> PacketType.Handshake.Client::class.java
+                "login" -> PacketType.Login.Client::class.java
+                "status" -> PacketType.Status.Client::class.java
+                else -> PacketType.Play.Client::class.java
             }
         } else {
             when(senderRaw.lowercase()) {
-                "play" -> type = PacketType.Play.Server::class.java
-                "handshake" -> type = PacketType.Handshake.Server::class.java
-                "login" -> type = PacketType.Login.Server::class.java
-                "status" -> type = PacketType.Status.Server::class.java
-                else -> type = PacketType.Play.Server::class.java
+                "play" -> PacketType.Play.Server::class.java
+                "handshake" -> PacketType.Handshake.Server::class.java
+                "login" -> PacketType.Login.Server::class.java
+                "status" -> PacketType.Status.Server::class.java
+                else -> PacketType.Play.Server::class.java
             }
         }
 

--- a/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/utils/UIUtils.kt
+++ b/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/utils/UIUtils.kt
@@ -21,7 +21,7 @@ object UIUtils {
                 actions[parameters[0] as Int] = parameters[2] as V8Function
             }, "slot")
 
-            registerJavaMethod({ _, parameters ->
+            registerJavaMethod({ _, _ ->
                 val type = when(size) {
                     9 -> InventoryType.CHEST_9
                     18 -> InventoryType.CHEST_18

--- a/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/utils/V8Ext.kt
+++ b/bukkit/src/main/kotlin/org/netherald/minejs/bukkit/utils/V8Ext.kt
@@ -1,0 +1,17 @@
+package org.netherald.minejs.bukkit.utils
+
+import com.eclipsesource.v8.V8Array
+import com.eclipsesource.v8.V8Object
+import com.eclipsesource.v8.V8Value
+
+fun V8Object.addNullable(key: String, obj: V8Value?) {
+    if (obj == null) {
+        this.addUndefined(key)
+    } else {
+        this.add(key, obj)
+    }
+}
+
+fun V8Array.getOrNull(index: Int): Any? {
+    return if (index > length()) this.get(index) else null
+}


### PR DESCRIPTION
## GetterSetter (이벤트 관련 메소드에 적용시켰습니다)
- `GetterSetter`는 자바스크립트의 `getX()`와 `setX()` 함수를 `DSL`로 쉽게 만들 수 있습니다.
```kotlin
GetterSetter<Int>("level") {
    getter {
        entity.level
    }
    setter { level ->
        entity.level = level
    }
}
// getLevel()과 setLevel()을 만듭니다.
```

## JsLinker (아직 활용 x)
- `JsLinker`은 자바의 클래스를 자바스크립트 객체로 또는 그 반대로 변환시켜주는 유틸리티입니다.
```kotlin
class MyLinker(@field:JsLinkValue val name: String): JsLinkable {    // 자바스크립트 name 값으로 변환
    @JsLinkMethod
    fun myMethod() {    // 자바스크립트 myMethod() 함수로 변환
        println("Hello, World! My name is $name")
    }
}
```
## 기타 최적화
- 반복되는 코드를 `EventUtil`로 꺼내어 코드를 재사용 가능하게 합니다.
- `if`, `when`문을 꺼낼 수 있는 코틀린 기능을 사용하였습니다.